### PR TITLE
Stop using deprecated mktime() syntax

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -199,7 +199,7 @@ function delta_days($day, $month)
   $thisYear = date("Y");
   $lastYear = date("Y")-1;
   $nextYear = date("Y")+1;
-  $todayday = strtotime(date("Ymd", mktime()));
+  $todayday = strtotime(date("Ymd", time()));
   $lastYearDiff = strtotime("$lastYear-$month-$day") - $todayday;
   $thisYearDiff = strtotime("$thisYear-$month-$day") - $todayday;
   $nextYearDiff = strtotime("$nextYear-$month-$day") - $todayday;
@@ -223,7 +223,7 @@ function bday_fancy($day, $month, $year)
     $thisYear = date("Y");
     $lastYear = date("Y")-1;
     $nextYear = date("Y")+1;
-    $todayday = strtotime(date("Ymd", mktime()));
+    $todayday = strtotime(date("Ymd", time()));
     $lastYearDiff = strtotime("$lastYear-$month-$day") - $todayday;
     $thisYearDiff = strtotime("$thisYear-$month-$day") - $todayday;
     $nextYearDiff = strtotime("$nextYear-$month-$day") - $todayday;


### PR DESCRIPTION
This patch was sitting around in production. I don't know who made the change; perhaps one of our previous sysadmins. Anyway, I thought I'd upstream it to you :)